### PR TITLE
DTE-793: use only first 8 chars of uuid in SF name

### DIFF
--- a/tre-sqs-sf-trigger/tre_sqs_sf_trigger.py
+++ b/tre-sqs-sf-trigger/tre_sqs_sf_trigger.py
@@ -123,8 +123,8 @@ def execute_step_function(
     tre_message['properties']['parentExecutionId'] = input_execution_id
 
 
-    # Build execution name
-    name_list = [consignment_ref, event_source, fresh_execution_id]
+    # Build execution name using only first 8 chars of the uuid
+    name_list = [consignment_ref, event_source, fresh_execution_id[0:8]]
     logger.info('name_list=%s', name_list)
     execution_name = NAME_SEPARATOR.join(name_list)
     logger.info('execution_name=%s', execution_name)


### PR DESCRIPTION
SF names previously became over 80 chars, by only taking the first 8 chars of the uuid into the SF name we stay well away from the limit with for example: `FCL-MK-LONG-AS-YOU-LIKE-pte-mk-tre-court-document-pack-in-90ddfa26` being 67 chars.

Works in PTE.

  